### PR TITLE
2 little typos

### DIFF
--- a/lib/IncomingStreamBridge.js
+++ b/lib/IncomingStreamBridge.js
@@ -51,7 +51,7 @@ class IncomingStreamBridge extends Emitter
 			//If it is the same as ours
 			if (this.stream===stream)
 				//Dettach
-				this.dettach();	
+				this.detach();	
 		};
 	}
 	
@@ -137,7 +137,7 @@ class IncomingStreamBridge extends Emitter
 		return video;
 	}
 	
-	dettach()
+	detach()
 	{
 		//If we had an stream
 		if (this.stream)
@@ -154,7 +154,7 @@ class IncomingStreamBridge extends Emitter
 	attachTo(/** @type {import("./Stream")} */ stream)
 	{
 		//Dettach just in case
-		this.dettach();
+		this.detach();
 		
 		//If attaching to a stream
 		if (stream)
@@ -179,7 +179,7 @@ class IncomingStreamBridge extends Emitter
 		if (!this.bridge) return;
 		
 		//Dettach
-		this.dettach();
+		this.detach();
 		
 		//Stop all streams
 		for (let track of this.tracks.values())

--- a/lib/IncomingStreamBridge.js
+++ b/lib/IncomingStreamBridge.js
@@ -51,7 +51,7 @@ class IncomingStreamBridge extends Emitter
 			//If it is the same as ours
 			if (this.stream===stream)
 				//Dettach
-				this.detach();	
+				this.detach();
 		};
 	}
 	
@@ -137,6 +137,12 @@ class IncomingStreamBridge extends Emitter
 		return video;
 	}
 	
+	/** @deprecated */
+	dettach()
+	{
+		return this.detach();
+	}
+
 	detach()
 	{
 		//If we had an stream

--- a/lib/IncomingStreamTrackBridge.js
+++ b/lib/IncomingStreamTrackBridge.js
@@ -332,7 +332,7 @@ class IncomingStreamTrackBridge extends Emitter
 	/**
 	 * Get all track encodings
 	 * Internal use, you'd beter know what you are doing before calling this method
-	 * @returns {Array<Object>} - encodings 
+	 * @returns {Array<Encoding>} - encodings 
 	 **/
 	getEncodings()
 	{

--- a/lib/Stream.js
+++ b/lib/Stream.js
@@ -95,7 +95,9 @@ class Stream extends Emitter
 		if (maxBufferingTime>1000)
 			throw Error("maxBufferingTime can't be higher than 1000");
 
-		return new IncomingStreamBridge(this.stream, maxLateOffset, maxBufferingTime);
+		const bridge = new IncomingStreamBridge(maxLateOffset, maxBufferingTime);
+		bridge.attachTo(this);
+		return bridge;
 	}
 	
 	stop()


### PR DESCRIPTION
normally i wouldn't care about a typo if it's on an API, but it must be called `detach()` to implement the media server API correctly