### PR TITLE
Skip track stats if no frame received

### DIFF
--- a/lib/IncomingStreamTrackBridge.js
+++ b/lib/IncomingStreamTrackBridge.js
@@ -168,6 +168,11 @@ class IncomingStreamTrackBridge extends Emitter
 		for (let encoding of this.encodings.values())
 		{
 			const { id, bridge } = encoding;
+			
+			if (bridge.numFrames == 0)
+			{
+				continue;
+			}
 
 			//Check if we have cachedd stats
 			if (!this.stats[id] || (Date.now() - this.stats[id].timestamp)>200 )


### PR DESCRIPTION
When stats is sent before frame received, it appears "unkown codec and media" in the codec stats, which is not consistent with WebRTC.