### PR TITLE
Npm pack and publish through github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish
+on: 
+  release:
+   types: [published]
+  push:
+    branches:
+      - 'lester/*'
+
+jobs:
+  publish-npmjs:
+    permissions:
+      packages: write
+      contents: read
+    uses: millicast/github-actions/.github/workflows/npm-publish.yml@main
+    with:
+      registry-url: 'https://registry.npmjs.org/'
+    secrets:
+      token: ${{ secrets.NPMJS_PUBLISH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 name: Publish
 on: 
-  release:
-   types: [published]
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   publish-npmjs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,6 @@ name: Publish
 on: 
   release:
    types: [published]
-  push:
-    branches:
-      - 'lester/*'
 
 jobs:
   publish-npmjs:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "swig": "swig -javascript -node -c++ src/rtmp-server.i",
     "build": "node-gyp build --jobs=max",
     "install": "test -f build/Release/medooze-rtmp-server.node || (node-gyp configure && node-gyp rebuild --jobs=max)",
-    "package": "npm run prepare && tar cvzf build/medooze-rtmp-server.tgz  `([ \"$(uname)\" = 'Darwin' ] && echo \"-s |^|medooze-rtmp-server/|\") || echo \" --transform=flags=r;s|^|medooze-rtmp-server/|\"` media-server/src/* media-server/include/* media-server/ext/libdatachannels/src/* media-server/ext/crc32c/* lib/* package.json index.js index.d.ts build/types binding.gyp  README.md src",
     "dist": "npm run configure && npm run build && npm run prepare && mkdir -p dist && tar cvzf dist/medooze-rtmp-server-`node -e 'console.log(require(\"./package.json\").version)'`.tgz `([ \"$(uname)\" = 'Darwin' ] && echo \"-s |^|medooze-rtmp-server/|\") || echo \" --transform=flags=r;s|^|medooze-rtmp-server/|\"` package.json index.js index.d.ts build/types  README.md lib/* build/Release/medooze-rtmp-server.node",
     "test": "tap tests/*.js --cov --no-check-coverage"
   },
@@ -40,5 +39,19 @@
     "@types/node": "^20.8.6",
     "@types/uuid": "^9.0.5",
     "typescript": "^5.2.2"
-  }
+  },
+  "files": [
+    "media-server/src/*",
+    "media-server/include/*",
+    "media-server/ext/libdatachannels/src/*",
+    "media-server/ext/crc32c/*",
+    "lib/*",
+    "package.json",
+    "index.js",
+    "index.d.ts",
+    "build/types",
+    "binding.gyp",
+    "README.md",
+    "src"
+  ]
 }


### PR DESCRIPTION
Only difference between the pacakges is npm includes license and readme's by default:
![image](https://github.com/medooze/rtmp-server-node/assets/145613755/ca094d31-d331-4307-9844-f74845cbd243)

Sample publishing run: 
https://github.com/medooze/rtmp-server-node/actions/runs/9036957458/job/24834949078